### PR TITLE
Simplified package structure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,27 +6,11 @@ import PackageDescription
 let package = Package(
     name: "Fun",
     products: [
-        .library(
-            name: "Fun",
-            targets: [
-                "Operators",
-                "Functions"
-            ]
-        )
+        .library(name: "Fun", targets: ["Fun"])
     ],
     targets: [
-        .target(name: "Operators"),
-        .target(name: "Functions"),
+        .target(name: "Fun"),
         .target(name: "TestHelpers", path: "Tests/Helpers"),
-        .testTarget(name: "OperatorsTests", dependencies: ["Operators", "TestHelpers"]),
-        .testTarget(name: "FunctionsTests", dependencies: ["Functions", "TestHelpers"]),
-        .testTarget(
-            name: "IntegrationTests",
-            dependencies: [
-                "Operators",
-                "Functions",
-                "TestHelpers"
-            ]
-        )
+        .testTarget(name: "FunTests", dependencies: ["Fun", "TestHelpers"])
     ]
 )

--- a/Sources/Fun/Functions/Curry.swift
+++ b/Sources/Fun/Functions/Curry.swift
@@ -1,6 +1,6 @@
 //
 //  Curry.swift
-//  Functions
+//  Fun
 //
 //  Created by Mikhail Dudarev on 30.04.2023.
 //

--- a/Sources/Fun/Functions/Filter.swift
+++ b/Sources/Fun/Functions/Filter.swift
@@ -1,6 +1,6 @@
 //
 //  Filter.swift
-//  Functions
+//  Fun
 //
 //  Created by Mikhail Dudarev on 01.05.2023.
 //

--- a/Sources/Fun/Functions/Flip.swift
+++ b/Sources/Fun/Functions/Flip.swift
@@ -1,6 +1,6 @@
 //
 //  Flip.swift
-//  Functions
+//  Fun
 //
 //  Created by Mikhail Dudarev on 01.05.2023.
 //

--- a/Sources/Fun/Functions/Map.swift
+++ b/Sources/Fun/Functions/Map.swift
@@ -1,6 +1,6 @@
 //
 //  Map.swift
-//  Functions
+//  Fun
 //
 //  Created by Mikhail Dudarev on 01.05.2023.
 //

--- a/Sources/Fun/Operators/Compose/ForwardComposition.swift
+++ b/Sources/Fun/Operators/Compose/ForwardComposition.swift
@@ -1,6 +1,6 @@
 //
 //  ForwardComposition.swift
-//  Operators
+//  Fun
 //
 //  Created by Mikhail Dudarev on 29.04.2023.
 //

--- a/Sources/Fun/Operators/Compose/SingleTypeComposition.swift
+++ b/Sources/Fun/Operators/Compose/SingleTypeComposition.swift
@@ -1,6 +1,6 @@
 //
 //  SingleTypeComposition.swift
-//  Operators
+//  Fun
 //
 //  Created by Mikhail Dudarev on 30.04.2023.
 //

--- a/Sources/Fun/Operators/Pipe.swift
+++ b/Sources/Fun/Operators/Pipe.swift
@@ -1,6 +1,6 @@
 //
 //  Pipe.swift
-//  Operators
+//  Fun
 //
 //  Created by Mikhail Dudarev on 29.04.2023.
 //

--- a/Tests/FunTests/FunTests.swift
+++ b/Tests/FunTests/FunTests.swift
@@ -1,16 +1,15 @@
 //
-//  IntegrationTests.swift
-//  IntegrationTests
+//  FunTests.swift
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 01.05.2023.
 //
 
-import Functions
-import Operators
+import Fun
 @testable import TestHelpers
 import XCTest
 
-final class IntegrationTests: XCTestCase {
+final class FunTests: XCTestCase {
     func test() throws {
         XCTAssertEqual(2 |> increment >>> square >>> String.init, "9")
         XCTAssertEqual([1, 2, 3, 4] |> filter(isEven) >>> map(increment >>> square), [9, 25])

--- a/Tests/FunTests/FunctionsTests/Curry.swift
+++ b/Tests/FunTests/FunctionsTests/Curry.swift
@@ -1,11 +1,11 @@
 //
 //  Curry.swift
-//  FunctionsTests
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 29.04.2023.
 //
 
-import Functions
+import Fun
 @testable import TestHelpers
 import XCTest
 

--- a/Tests/FunTests/FunctionsTests/Filter.swift
+++ b/Tests/FunTests/FunctionsTests/Filter.swift
@@ -1,11 +1,11 @@
 //
 //  Filter.swift
-//  FunctionsTests
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 01.05.2023.
 //
 
-import Functions
+import Fun
 @testable import TestHelpers
 import XCTest
 

--- a/Tests/FunTests/FunctionsTests/Flip.swift
+++ b/Tests/FunTests/FunctionsTests/Flip.swift
@@ -1,11 +1,11 @@
 //
 //  Flip.swift
-//  FunctionsTests
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 01.05.2023.
 //
 
-import Functions
+import Fun
 @testable import TestHelpers
 import XCTest
 

--- a/Tests/FunTests/FunctionsTests/Map.swift
+++ b/Tests/FunTests/FunctionsTests/Map.swift
@@ -1,11 +1,11 @@
 //
 //  Map.swift
-//  FunctionsTests
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 01.05.2023.
 //
 
-import Functions
+import Fun
 @testable import TestHelpers
 import XCTest
 

--- a/Tests/FunTests/OperatorsTests/Compose/ForwardCompositionTests.swift
+++ b/Tests/FunTests/OperatorsTests/Compose/ForwardCompositionTests.swift
@@ -1,11 +1,11 @@
 //
 //  ForwardCompositionTests.swift
-//  OperatorsTests
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 29.04.2023.
 //
 
-import Operators
+import Fun
 @testable import TestHelpers
 import XCTest
 

--- a/Tests/FunTests/OperatorsTests/Compose/SingleTypeCompositionTests.swift
+++ b/Tests/FunTests/OperatorsTests/Compose/SingleTypeCompositionTests.swift
@@ -1,11 +1,11 @@
 //
 //  SingleTypeCompositionTests.swift
-//  OperatorsTests
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 30.04.2023.
 //
 
-import Operators
+import Fun
 @testable import TestHelpers
 import XCTest
 

--- a/Tests/FunTests/OperatorsTests/PipeTests.swift
+++ b/Tests/FunTests/OperatorsTests/PipeTests.swift
@@ -1,11 +1,11 @@
 //
 //  PipeTests.swift
-//  OperatorsTests
+//  FunTests
 //
 //  Created by Mikhail Dudarev on 29.04.2023.
 //
 
-import Operators
+import Fun
 @testable import TestHelpers
 import XCTest
 

--- a/Tests/Helpers/FreeFunctions.swift
+++ b/Tests/Helpers/FreeFunctions.swift
@@ -1,6 +1,6 @@
 //
 //  FreeFunctions.swift
-//  OperatorsTests
+//  TestHelpers
 //
 //  Created by Mikhail Dudarev on 29.04.2023.
 //


### PR DESCRIPTION
All existing public code now resides in single target, so only one line of code is required to import everything.